### PR TITLE
Switch out CJS module.exports for ES export default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const semver = require('semver');
 
-module.exports = (versionA, versionB) => {
+export default (versionA, versionB) => {
 	if (semver.gt(versionA, versionB)) {
 		return;
 	}


### PR DESCRIPTION
I'm in the unfortunate position of having to support IE11 which doesn't like the arrow function or use of const in the for loop.

This means I'm having to get babel to transpile the package.  I'm using `@babel/preset-env` with `useBuiltIns: "usage"`, so it inserts import statements into the package.  

Mixing these imports with module.exports causes things to break.  I'm working around this by adding sourceType: "unambiguous" to my babel config so that it detects semver-diff as being commonjs and injects require statements instead which will play nicely with module.exports.

Seeing as sourceType: "unambiguous" isn't 100% accurate however, it would be preferable if `module.exports` was swapped out for the ES module equivalent `export default`. 