### PR TITLE
Return undefined if the second version has an older build

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,7 @@ module.exports = (versionA, versionB) => {
 	versionA = semver.parse(versionA);
 	versionB = semver.parse(versionB);
 
-	const cmpResult = semver.compareBuild(versionA, versionB);
-	if (cmpResult >= 0) {
+	if (semver.compareBuild(versionA, versionB) >= 0) {
 		return;
 	}
 

--- a/index.js
+++ b/index.js
@@ -2,26 +2,13 @@
 const semver = require('semver');
 
 module.exports = (versionA, versionB) => {
-	if (semver.gt(versionA, versionB)) {
-		return;
-	}
-
 	versionA = semver.parse(versionA);
 	versionB = semver.parse(versionB);
 
-	for (const key of Object.keys(versionA)) {
-		if (key === 'major' || key === 'minor' || key === 'patch') {
-			if (versionA[key] !== versionB[key]) {
-				return key;
-			}
-		}
-
-		if (key === 'prerelease' || key === 'build') {
-			if (
-				JSON.stringify(versionA[key]) !== JSON.stringify(versionB[key])
-			) {
-				return key;
-			}
-		}
+	const cmpResult = semver.compareBuild(versionA, versionB);
+	if (cmpResult >= 0) {
+		return;
 	}
+
+	return semver.diff(versionA, versionB) || 'build';
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"difference"
 	],
 	"dependencies": {
-		"semver": "^6.0.0"
+		"semver": "^6.1.0"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",

--- a/test.js
+++ b/test.js
@@ -7,7 +7,16 @@ test('should get the semver diff type', t => {
 	t.is(semverDiff('0.0.1', '0.1.0'), 'minor');
 	t.is(semverDiff('0.0.1', '0.0.2'), 'patch');
 	t.is(semverDiff('0.0.1-foo', '0.0.1-foo.bar'), 'prerelease');
-	t.is(semverDiff('0.0.1', '0.0.1+foo.bar'), 'build');
 	t.is(semverDiff('0.0.1', '0.0.1'), undefined);
 	t.is(semverDiff('0.0.2', '0.0.1'), undefined);
+
+	t.is(semverDiff('0.0.1', '0.0.1+foo.bar'), 'build');
+	t.is(semverDiff('0.0.1+0', '0.0.1'), undefined);
+	t.is(semverDiff('0.0.1+2', '0.0.1+2'), undefined);
+	t.is(semverDiff('0.0.1+3', '0.0.1+2'), undefined);
+	t.is(semverDiff('0.0.1+1', '0.0.1+2'), 'build');
+	t.is(semverDiff('0.0.1+2', '0.0.1+2.0'), 'build');
+	t.is(semverDiff('0.0.1+2.0', '0.0.1+2'), undefined);
+	t.is(semverDiff('0.0.1+2.a', '0.0.1+2.0'), undefined);
+	t.is(semverDiff('0.0.1+2.0', '0.0.1+2.a'), 'build');
 });


### PR DESCRIPTION
Fixes #5

---

The semver update in package.json is necessary as `semver.compareBuild` is a new feature of 6.1.0.