### PR TITLE
Document missing return types `premajor`, `preminor`, and `prepatch`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace semverDiff {
-	type Result = 'major' | 'minor' | 'patch' | 'prerelease' | 'build';
+	type Result = 'major' | 'premajor' | 'minor' | 'preminor' | 'patch' | 'prepatch' | 'prerelease' | 'build';
 }
 
 /**
@@ -14,11 +14,20 @@ import semverDiff = require('semver-diff');
 semverDiff('1.1.1', '1.1.2');
 //=> 'patch'
 
+semverDiff('1.1.1-foo', '1.1.2');
+//=> 'prepatch'
+
 semverDiff('0.0.1', '1.0.0');
 //=> 'major'
 
+semverDiff('0.0.1-foo', '1.0.0');
+//=> 'premajor'
+
 semverDiff('0.0.1', '0.1.0');
 //=> 'minor'
+
+semverDiff('0.0.1-foo', '0.1.0');
+//=> 'preminor'
 
 semverDiff('0.0.1-foo', '0.0.1-foo.bar');
 //=> 'prerelease'

--- a/readme.md
+++ b/readme.md
@@ -18,11 +18,20 @@ const semverDiff = require('semver-diff');
 semverDiff('1.1.1', '1.1.2');
 //=> 'patch'
 
+semverDiff('1.1.1-foo', '1.1.2');
+//=> 'prepatch'
+
 semverDiff('0.0.1', '1.0.0');
 //=> 'major'
 
+semverDiff('0.0.1-foo', '1.0.0');
+//=> 'premajor'
+
 semverDiff('0.0.1', '0.1.0');
 //=> 'minor'
+
+semverDiff('0.0.1-foo', '0.1.0');
+//=> 'preminor'
 
 semverDiff('0.0.1-foo', '0.0.1-foo.bar');
 //=> 'prerelease'
@@ -44,7 +53,7 @@ semverDiff('0.0.2', '0.0.1');
 
 Returns the difference type between two semver versions, or `undefined` if they're identical or the second one is lower than the first.
 
-Possible values: `'major'`, `'minor'`, `'patch'`, `'prerelease'`, `'build'`, `undefined`.
+Possible values: `'major'`, `'premajor'`, `'minor'`, `'preminor'`, `'patch'`, `'prepatch'`, `'prerelease'`, `'build'`, `undefined`.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -6,6 +6,9 @@ test('should get the semver diff type', t => {
 	t.is(semverDiff('0.0.1', '1.0.0'), 'major');
 	t.is(semverDiff('0.0.1', '0.1.0'), 'minor');
 	t.is(semverDiff('0.0.1', '0.0.2'), 'patch');
+	t.is(semverDiff('0.0.1-foo', '1.0.0'), 'premajor');
+	t.is(semverDiff('0.0.1-foo', '0.1.0'), 'preminor');
+	t.is(semverDiff('1.1.1-foo', '1.1.2'), 'prepatch');
 	t.is(semverDiff('0.0.1-foo', '0.0.1-foo.bar'), 'prerelease');
 	t.is(semverDiff('0.0.1', '0.0.1'), undefined);
 	t.is(semverDiff('0.0.2', '0.0.1'), undefined);


### PR DESCRIPTION
Include missing return types 'premajor', 'preminor' and 'prepatch' in tests, TS types and examples.

Resolves #8 